### PR TITLE
Updates Ruby test version, updates nokogiri

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         ruby:
-          - '3.0'
+          - '3.2'
 
     steps:
     - uses: actions/checkout@v4

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -48,11 +48,11 @@ GEM
       nokogiri (>= 1.12.0)
     minitest (5.25.4)
     mutex_m (0.3.0)
-    nokogiri (1.17.2-arm64-darwin)
+    nokogiri (1.18.3-arm64-darwin)
       racc (~> 1.4)
-    nokogiri (1.17.2-x86_64-darwin)
+    nokogiri (1.18.3-x86_64-darwin)
       racc (~> 1.4)
-    nokogiri (1.17.2-x86_64-linux)
+    nokogiri (1.18.3-x86_64-linux-gnu)
       racc (~> 1.4)
     parallel (1.26.3)
     parser (3.3.7.1)
@@ -136,4 +136,4 @@ DEPENDENCIES
   rubocop-rails-accessibility!
 
 BUNDLED WITH
-   2.3.7
+   2.4.10

--- a/rubocop-rails-accessibility.gemspec
+++ b/rubocop-rails-accessibility.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |spec|
   spec.summary = "Custom RuboCop rules for Rails Accessibility."
   spec.homepage = "https://github.com/github/rubocop-rails-accessibility"
   spec.license = "MIT"
-  spec.required_ruby_version = ">= 3.0.0"
+  spec.required_ruby_version = ">= 3.2.0"
 
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["source_code_uri"] = spec.homepage


### PR DESCRIPTION
Related to https://github.com/github/vuln-mgmt/issues/139190.

Updates nokogiri to fix security updates. To do this, we were required to update the Ruby version as well. I chose to go right to 3.2 since 3.1 is pretty old.